### PR TITLE
Silently ignore deleting non existent files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
+        "@types/uuid": "^9.0.2",
         "firebase-admin": "^11.4.1",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
+        "@tsconfig/node16": "1.0.3",
         "@types/node": "^18.11.18",
         "typescript": "^4.9.4"
       }
@@ -316,6 +318,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -418,6 +426,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -2366,6 +2379,12 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "optional": true
     },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -2468,6 +2487,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
     },
     "abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   "homepage": "https://github.com/shadow1349/strapi-provider-firebase-storage#readme",
   "devDependencies": {
     "@types/node": "^18.11.18",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "@tsconfig/node16": "1.0.3"
   },
   "dependencies": {
+    "@types/uuid": "^9.0.2",
     "firebase-admin": "^11.4.1",
     "uuid": "^9.0.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,19 +197,23 @@ module.exports = {
       delete: (file: File) =>
         new Promise((resolve, reject) => {
           const fileRef = getFileRef(file);
-
-          fileRef
-            .delete()
-            .then(() => {
-              print("\n\n");
-              // Resolve just markes that the delete is complete
-              resolve("");
+          fileRef.exists().then(([exists])=>{
+            if(!exists){
+              return resolve("");
+            }
+            fileRef
+              .delete()
+              .then(() => {
+                print("\n\n");
+                // Resolve just markes that the delete is complete
+                resolve("");
+              })
+              .catch((error) => {
+                if (config.debug) console.error(error);
+                print("\n\n");
+                reject(error);
+              });
             })
-            .catch((error) => {
-              if (config.debug) console.error(error);
-              print("\n\n");
-              reject(error);
-            });
         }),
     };
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,38 @@
 import * as admin from "firebase-admin";
 import * as path from "path";
 import { v4 } from "uuid";
+import {ReadStream} from 'fs';
+import {ServiceAccount} from 'firebase-admin/lib/app/credential';
+
+interface File {
+  name: string;
+  alternativeText?: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+  formats?: Record<string, unknown>;
+  hash: string;
+  ext?: string;
+  mime: string;
+  size: number;
+  url: string;
+  previewUrl?: string;
+  path?: string;
+  provider?: string;
+  provider_metadata?: Record<string, unknown>;
+  stream?: ReadStream;
+  buffer?: Buffer;
+}
+
+interface InitOptions {
+  serviceAccount: string | ServiceAccount;
+  bucket:string;
+  sortInStorage?:boolean;
+  debug?:boolean;
+}
 
 module.exports = {
-  init(config) {
+  init(config: InitOptions) {
     admin.initializeApp({
       credential: admin.credential.cert(config.serviceAccount),
       // If you have a custom bucket this will set that bucket
@@ -73,7 +102,7 @@ module.exports = {
     /**
      * We need the file ref for all functions so it makes sense to get that here.
      */
-    function getFileRef(file) {
+    function getFileRef(file: File) {
       const fileName = `${file.hash}${file.ext}`;
       print("FILE NAME: ", fileName);
 
@@ -91,7 +120,7 @@ module.exports = {
       return bucket.file(config.sortInStorage ? fullFilePath : fileName);
     }
 
-    const upload = (file) =>
+    const upload = (file: File) =>
       new Promise((resolve, reject) => {
         const fileRef = getFileRef(file);
 
@@ -163,9 +192,9 @@ module.exports = {
 
     return {
       // We can have 1 function that handles file streams and buffers
-      upload: (file) => upload(file),
-      uploadStream: (file) => upload(file),
-      delete: (file) =>
+      upload: (file: File) => upload(file),
+      uploadStream: (file: File) => upload(file),
+      delete: (file: File) =>
         new Promise((resolve, reject) => {
           const fileRef = getFileRef(file);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "module": "CommonJS",
-    "esModuleInterop": true,
-    "target": "es2015",
-    "moduleResolution": "node",
+    "declaration": true,
     "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
     "outDir": "dist"
   },
-  "lib": ["es2015"]
+  "include": ["src"],
+  "exclude": ["node_modules", "**/__tests__/**"]
 }


### PR DESCRIPTION
When import/exporting data, I often run into an issue where it fails due to files in production not existing in test.

This PR checks if the files exists in the bucket, and silently skips deletion if it does not.
